### PR TITLE
ENH: Add cmd-line arg for specifying config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,20 @@
 # beamtime-calibration-suite
 [![Build Status](https://github.com/slaclab/beamtime-calibration-suite/actions/workflows/run-tests.yml/badge.svg?branch=main)](https://github.com/slaclab/beamtime-calibration-suite/actions/workflows/run-tests.yml)
 
+## Environment Variables
 To run any suite_scripts or use the library in scripts outside the project directory, you need to append the location of your project directory to your PYTHONPATH, for example:
 ``` 
 export PYTHONPATH="${PYTHONPATH}:~/nolan/repos/beamtime-calibration-suite"
 ```
 _(can add this to your ~/.bashrc so persists between terminal sessions. Library can later have a better release method than cloning and adding to path (pip?))_
+
+Additionally you can specify which config file to use by setting the 'SUITE_CONFIG' environment variable, for example:
+``` 
+export SUITE_CONFIG="rixConfig.py" 
+```
+_(relative or full paths work)_  
+You can also set the config-file using the '-cf' or '--configFile' cmd-line arguments _(note: if set, the environment variable overrides this cmd-line option)_  
+If neither of the above are set, the suite will try to use 'suiteConfig.py'. If no config file can be found and read, the library will fail-out early.
 
 ## File organization: 
 * /calibrationSuite: The library code lives here, and the functions can be imported into other scripts as such:

--- a/suite_scripts/AnalyzeH5.py
+++ b/suite_scripts/AnalyzeH5.py
@@ -1,7 +1,7 @@
 import h5py
 import numpy as np
-from calibrationSuite.fitFunctions import *
-from calibrationSuite.ancillaryMethods import *
+import calibrationSuite.fitFunctions as fitFunctions
+import calibrationSuite.ancillaryMethods as ancillaryMethods
 ##import seaborn as sns
 import matplotlib.pyplot as plt
 from matplotlib.ticker import AutoMinorLocator

--- a/suite_scripts/rixSuiteConfig.py
+++ b/suite_scripts/rixSuiteConfig.py
@@ -1,11 +1,3 @@
-import os
-if os.getenv('foo') == '1':
-    print("psana1")
-    from calibrationSuite.psana1Base import *
-else:
-    print("psana2")
-    from calibrationSuite.psana2Base import *
-
 import numpy as np
 
 ##experimentHash = {'exp':'mfxx1005021', 'location':'MfxEndstation', 'fluxSource':'MFX-USR-DIO', 'fluxChannels':[11], 'fluxSign':-1}


### PR DESCRIPTION
-add '-cf' or '--configFile' for specifying config file
-move import of psana1 vs psana2 out of config file and into basicSuiteScript
-add 'importConfigFile' function that runs config file's python code
    -move cmd-line parsing before this function in file, so it can use -cf flag value